### PR TITLE
Stop infinite players being created

### DIFF
--- a/Game/Assets/Scenes/StartMenu/Scripts/NewGame.cs
+++ b/Game/Assets/Scenes/StartMenu/Scripts/NewGame.cs
@@ -4,6 +4,7 @@ using UnityEngine.SceneManagement;
 public class NewGame : MonoBehaviour{
 
     public GameObject playerPrefab;
+    GameObject playerObject;
 
     public void StartNewGame() {
 
@@ -20,7 +21,14 @@ public class NewGame : MonoBehaviour{
         };
         AreaDataLoader.InitAreaRegionItems(1,regionItems);
 
-        Instantiate(playerPrefab).GetComponent<Player>().Init();
+        // Try to find player game object
+        playerObject = GameObject.Find("Player");
+
+        // If player game object does not exist, create it
+        if (playerObject == null) {
+            Instantiate(playerPrefab).GetComponent<Player>().Init();
+        } // Else, just continue with already created player
+        
         SceneManager.LoadScene("InGameMenu");
 
     }

--- a/Game/Assets/Scenes/StartMenu/Scripts/NewGame.cs
+++ b/Game/Assets/Scenes/StartMenu/Scripts/NewGame.cs
@@ -4,7 +4,6 @@ using UnityEngine.SceneManagement;
 public class NewGame : MonoBehaviour{
 
     public GameObject playerPrefab;
-    GameObject playerObject;
 
     public void StartNewGame() {
 
@@ -22,7 +21,7 @@ public class NewGame : MonoBehaviour{
         AreaDataLoader.InitAreaRegionItems(1,regionItems);
 
         // Try to find player game object
-        playerObject = GameObject.Find("Player");
+        GameObject playerObject = GameObject.Find("Player");
 
         // If player game object does not exist, create it
         if (playerObject == null) {


### PR DESCRIPTION
This contains the bad practice way of finding a player game object, but it does stop the creation of a new player being created when entering the start menu and going back again.

*This should be changed once save-files are implemented.*