### PR TITLE
Bugfix: HeatWave no longer crashes game

### DIFF
--- a/Game/Assets/Scenes/Combat/Scripts/Skills/HeatWave.cs
+++ b/Game/Assets/Scenes/Combat/Scripts/Skills/HeatWave.cs
@@ -30,8 +30,8 @@ public class HeatWave : Skill {
         Combat combat = target.c;
         List<Enemy> enemies = combat.Enemies;
 
-        foreach (GameCharacter enemy in enemies){
-            enemy.TakeDamage(Mathf.FloorToInt(damageDealt));
+        for (int i = enemies.Count - 1; i >= 0; i--) {
+            enemies[i].TakeDamage(Mathf.FloorToInt(damageDealt));
         }
 
         return true;


### PR DESCRIPTION
Change from a `foreach` to a reversed `for`-loop. `foreach` throws error when list it's operating on is changed, reversed `for` does not.