### PR TITLE
Add item description to inventory menu

### DIFF
--- a/Game/Assets/Scenes/Combat/Scripts/Items/Weapons/Knife.cs
+++ b/Game/Assets/Scenes/Combat/Scripts/Items/Weapons/Knife.cs
@@ -8,7 +8,7 @@ public class Knife : Weapon{
         sprites: new List<Sprite> {Resources.Load<Sprite>("Sprites/Items/knife1"), Resources.Load<Sprite>("Sprites/Items/knife2")},
         name: "Knife",
         value: 15,
-        description: "A slightly blunt kitchen knife that has been used many times for multiple things..",
+        description: "A slightly blunt kitchen knife that has been used many times for multiple things.",
         vitalityAdd: 0,
         vitalityMult: 1,
         armorAdd: 0,

--- a/Game/Assets/Scenes/Inventory/Scripts/ItemDescription.cs
+++ b/Game/Assets/Scenes/Inventory/Scripts/ItemDescription.cs
@@ -63,6 +63,7 @@ public class ItemDescription : MonoBehaviour{
                 break;
 
         }
+        description += $"\n<i>{target.Description}</i>";
 
         slide.transform.GetChild(1).GetComponent<TMP_Text>().text = description;
         currentDisplay = target;

--- a/Game/Assets/Scenes/Inventory/Scripts/ItemDescription.cs
+++ b/Game/Assets/Scenes/Inventory/Scripts/ItemDescription.cs
@@ -63,6 +63,7 @@ public class ItemDescription : MonoBehaviour{
                 break;
 
         }
+        
         description += $"\n<i>{target.Description}</i>";
 
         slide.transform.GetChild(1).GetComponent<TMP_Text>().text = description;


### PR DESCRIPTION
Not tested for all lengths of descriptions, so might need fixing if description is too long. Works for items in inventory right now.