### PR TITLE
 Bugfix: Make longer item descriptions readable in inventory

### DIFF
--- a/Game/Assets/Scenes/Inventory/Scripts/ItemDescription.cs
+++ b/Game/Assets/Scenes/Inventory/Scripts/ItemDescription.cs
@@ -64,7 +64,7 @@ public class ItemDescription : MonoBehaviour{
 
         }
         
-        description += $"\n<i>{target.Description}</i>";
+        description += $"\n<i><size=75%>{target.Description}</size></i>";
 
         slide.transform.GetChild(1).GetComponent<TMP_Text>().text = description;
         currentDisplay = target;


### PR DESCRIPTION
Shrink text size to more appropriate size to make longer descriptions fit better _(Excalibur)_.