### PR TITLE
Bugfix: Fix area1 asset and add meta for a png

### DIFF
--- a/Game/Assets/Resources/LevelData/Area1.asset
+++ b/Game/Assets/Resources/LevelData/Area1.asset
@@ -14,6 +14,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   areaIndex: 1
   areaName: Area1
-  backgroundImage: {fileID: 2979148220289618135, guid: 49a0a314a0f49504286984d924596d12, type: 3}
+  backgroundImage: {fileID: 3192242410833566051, guid: 2d7787b7585a13c44a36d014d67c4887, type: 3}
   bgm: {fileID: 0}
   unlock: 1

--- a/Game/Assets/Scenes/Combat/Resources/Sprites/Characters/shadowGround.png.meta
+++ b/Game/Assets/Scenes/Combat/Resources/Sprites/Characters/shadowGround.png.meta
@@ -147,7 +147,8 @@ TextureImporter:
     secondaryTextures: []
     spriteCustomMetadata:
       entries: []
-    nameFileIdTable: {}
+    nameFileIdTable:
+      shadowGround_0: -6518216050269918999
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 


### PR DESCRIPTION
Fix area1 leveldata asset to include correct background for area 1. Also add some meta that was changed, I love meta.