### PR TITLE
Fixed path substring fix to make save files compatible with UNIX

### DIFF
--- a/Game/Assets/Scenes/StartMenu/Scripts/NewGame.cs
+++ b/Game/Assets/Scenes/StartMenu/Scripts/NewGame.cs
@@ -47,7 +47,7 @@ public class NewGame : MonoBehaviour{
         }
 
         string[] files = Directory.GetFiles("Saves");
-        Save temp = new SaveManager().ReadSave(files[files.Length-1].Split('\\')[1]); // Load latest save
+        Save temp = new SaveManager().ReadSave(files[files.Length-1].Substring(6)); // Load latest save
         playerObject.GetComponent<Player>().LoadPlayer(temp);
         GetComponent<SceneSwitch>().SwitchScene(1);
 


### PR DESCRIPTION
Changed from split on backslash, to substring from index 6 _(removes Saves{/ or \} from save file string)_.

This makes the save files compatible with UNIX as well as compared to Windows only.