### PR TITLE
Update render mode of InGameMenu

### DIFF
--- a/Game/Assets/Scenes/Combat/Prefabs/GladiatorBoss.prefab.meta
+++ b/Game/Assets/Scenes/Combat/Prefabs/GladiatorBoss.prefab.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
 <<<<<<<< HEAD:Game/Assets/Scenes/Map/Sprites.meta
-guid: 8874a202d6d504460baf5e4eb0d7764f
+guid: 99bd919074126469792be31a519dece0
 folderAsset: yes
 DefaultImporter:
 ========

--- a/Game/Assets/Scenes/InGameMenu/InGameMenu.unity
+++ b/Game/Assets/Scenes/InGameMenu/InGameMenu.unity
@@ -1174,8 +1174,8 @@ Canvas:
   m_GameObject: {fileID: 1107364421}
   m_Enabled: 1
   serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
+  m_RenderMode: 1
+  m_Camera: {fileID: 84207845}
   m_PlaneDistance: 100
   m_PixelPerfect: 0
   m_ReceivesEvents: 1
@@ -1221,7 +1221,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backgroundImage: {fileID: 5559760933540300020}
-  bossCounter: {fileID: 2100000, guid: e73a58f6e2794ae7b1b7e50b7fb811b0, type: 2}
 --- !u!1 &1138247259
 GameObject:
   m_ObjectHideFlags: 0
@@ -1561,6 +1560,38 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1342100545}
   m_CullTransparentMesh: 1
+--- !u!1 &1393961583
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1393961584}
+  m_Layer: 0
+  m_Name: background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1393961584
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1393961583}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.31262612, y: -0.803134, z: 65.91587}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5559760933540300021}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1593588557
 GameObject:
   m_ObjectHideFlags: 0
@@ -1812,7 +1843,7 @@ PrefabInstance:
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 1393961584}
     m_Modifications:
     - target: {fileID: 2537302270328188794, guid: d1aca80d78f2ca44094ad46ff8a5dee7, type: 3}
       propertyPath: m_Camera
@@ -1822,6 +1853,10 @@ PrefabInstance:
       propertyPath: m_Sprite
       value: 
       objectReference: {fileID: 3192242410833566051, guid: 2d7787b7585a13c44a36d014d67c4887, type: 3}
+    - target: {fileID: 4867904425068513691, guid: d1aca80d78f2ca44094ad46ff8a5dee7, type: 3}
+      propertyPath: m_RaycastTarget
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5699692293892983069, guid: d1aca80d78f2ca44094ad46ff8a5dee7, type: 3}
       propertyPath: m_UiScaleMode
       value: 1
@@ -1912,7 +1947,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8516502779082971953, guid: d1aca80d78f2ca44094ad46ff8a5dee7, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 20
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8516502779082971953, guid: d1aca80d78f2ca44094ad46ff8a5dee7, type: 3}
       propertyPath: m_SizeDelta.y
@@ -1942,11 +1977,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!224 &5559760933540300021 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7891304795377270457, guid: d1aca80d78f2ca44094ad46ff8a5dee7, type: 3}
+  m_PrefabInstance: {fileID: 5559760933540300019}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 84207846}
-  - {fileID: 5559760933540300019}
+  - {fileID: 1393961584}
   - {fileID: 1107364425}
   - {fileID: 963447663}

--- a/Game/Assets/Scenes/InGameMenu/Sprites/Area 2.png.meta
+++ b/Game/Assets/Scenes/InGameMenu/Sprites/Area 2.png.meta
@@ -147,7 +147,8 @@ TextureImporter:
     secondaryTextures: []
     spriteCustomMetadata:
       entries: []
-    nameFileIdTable: {}
+    nameFileIdTable:
+      Area 2_0: 7754591102586423400
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Game/Assets/Scenes/InGameMenu/Sprites/Area 3.png.meta
+++ b/Game/Assets/Scenes/InGameMenu/Sprites/Area 3.png.meta
@@ -147,7 +147,8 @@ TextureImporter:
     secondaryTextures: []
     spriteCustomMetadata:
       entries: []
-    nameFileIdTable: {}
+    nameFileIdTable:
+      Area 3_0: -1521487376802658841
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Game/Assets/Scenes/Map/Sprites.meta
+++ b/Game/Assets/Scenes/Map/Sprites.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
 <<<<<<<< HEAD:Game/Assets/Scenes/Map/Sprites.meta
-guid: 8874a202d6d504460baf5e4eb0d7764f
+guid: 7f2f180e4dc2f4e09940b470cc893491
 folderAsset: yes
 DefaultImporter:
 ========

--- a/Game/Assets/Scenes/Map/Sprites/Map.png.meta
+++ b/Game/Assets/Scenes/Map/Sprites/Map.png.meta
@@ -147,7 +147,8 @@ TextureImporter:
     secondaryTextures: []
     spriteCustomMetadata:
       entries: []
-    nameFileIdTable: {}
+    nameFileIdTable:
+      Map_0: 645411862609229670
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 


### PR DESCRIPTION
Updated render mode of InGameMenu to Scren Space - Camera to align with rest of menus. This makes the switching between submenus (inventory, stats, skilltree) more seamless. 
Also updated hierachy of where background appears in scene, and disabled Raycast Target option to make buttons clickable.